### PR TITLE
Remove unneeded rawurlencode() before http_build_query() in BOGPaymen…

### DIFF
--- a/src/BOGPayment.php
+++ b/src/BOGPayment.php
@@ -24,10 +24,10 @@ class BOGPayment
     function redirect(array $additional_params = [], bool $preAuth = false): RedirectResponse
     {
         $lang = config('bogpayment.language');
-        $merchant_id = rawurlencode(config('bogpayment.merchant_id'));
-        $page_id = rawurlencode(config('bogpayment.page_id'));
-        $success_url = rawurlencode(URL::to(config('bogpayment.success_url')));
-        $fail_url = rawurlencode(URL::to(config('bogpayment.fail_url')));
+        $merchant_id = config('bogpayment.merchant_id');
+        $page_id = config('bogpayment.page_id');
+        $success_url = URL::to(config('bogpayment.success_url'));
+        $fail_url = URL::to(config('bogpayment.fail_url'));
 
         $params = array_merge([
             'lang' => $lang,


### PR DESCRIPTION
In new Georgian Card system (**mpi.gc.ge**) redirect url **doesn't** work anymore.

Because:
`http_build_query()` itself calls `urlencode()`.

What does the old code actually do?

```
$string = 'https://google.com'; // 'https://google.com'
$string = rawurlencode($string); // 'https%3A%2F%2Fgoogle.com'
$string = urlencode($string); // 'https%253A%252F%252Fgoogle.com'
```

Btw, if we want to use `rawurlencode()` instead of `urlencode()`, we can pass `PHP_QUERY_RFC3986` as the last parameter (`int $enc_type`) to `http_build_query()`